### PR TITLE
Divide OnUpdateListener

### DIFF
--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
@@ -59,7 +59,6 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 		this.mContext = (Context) activity;
 		this.mClickListener = (OnItemClickListener) activity;
 		this.onLoadCompleteListener = (OnLoadCompleteListener) activity;
-		this.onDeleteCompleteListener = (OnDeleteCompleteListener) activity;
 //		updateDataSet(listId);
 		updateDataSetAsync(listId);
 	}

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
@@ -56,9 +56,10 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 			mSelectAll = false;
 
 	public ExampleAdapter(Object activity, String listId) {
-		super(activity);
 		this.mContext = (Context) activity;
 		this.mClickListener = (OnItemClickListener) activity;
+		this.onLoadCompleteListener = (OnLoadCompleteListener) activity;
+		this.onDeleteCompleteListener = (OnDeleteCompleteListener) activity;
 //		updateDataSet(listId);
 		updateDataSetAsync(listId);
 	}

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
@@ -30,6 +30,7 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 		/**
 		 * Delegate the click event to the listener and check if selection MULTI enabled.<br/>
 		 * If yes, call toggleActivation.
+		 *
 		 * @param position
 		 * @return true if MULTI selection is enabled, false for SINGLE selection
 		 */
@@ -37,6 +38,7 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 
 		/**
 		 * This always calls toggleActivation after listener event is consumed.
+		 *
 		 * @param position
 		 */
 		void onListItemLongClick(int position);
@@ -65,6 +67,7 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 
 	/**
 	 * Param, in this example, is not used.
+	 *
 	 * @param param A custom parameter to filter the type of the DataSet
 	 */
 	@Override
@@ -88,7 +91,7 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 		super.setMode(mode);
 		if (mode == MODE_SINGLE) mLastItemInActionMode = true;
 	}
-	
+
 	@Override
 	public void selectAll() {
 		mSelectAll = true;
@@ -135,7 +138,7 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 			//IMPORTANT: Example View finishes here!!
 			return;
 		}
-		
+
 		//When user scrolls this bind the correct selection status
 		holder.itemView.setActivated(isSelected(position));
 
@@ -199,9 +202,8 @@ public class ExampleAdapter extends FlexibleAdapter<ExampleAdapter.SimpleViewHol
 	/**
 	 * Custom filter.
 	 *
-	 * @param myObject The item to filter
+	 * @param myObject   The item to filter
 	 * @param constraint the current searchText
-	 *
 	 * @return true if a match exists in the title or in the subtitle, false if no match found.
 	 */
 	@Override

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MainActivity.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MainActivity.java
@@ -64,21 +64,21 @@ public class MainActivity extends AppCompatActivity implements
 	private ProgressBar mProgressBar;
 	private SwipeRefreshLayout mSwipeRefreshLayout;
 	private final Handler mSwipeHandler = new Handler(Looper.getMainLooper(), new Handler.Callback() {
-			public boolean handleMessage(Message message) {
-				switch(message.what) {
-					case 0: //Stop
-						mSwipeRefreshLayout.setRefreshing(false);
-						mSwipeRefreshLayout.setEnabled(true);
-						return true;
-					case 1: //1 Start
-						mSwipeRefreshLayout.setRefreshing(true);
-						mSwipeRefreshLayout.setEnabled(false);
-						return true;
-					default:
-						return false;
-				}
+		public boolean handleMessage(Message message) {
+			switch (message.what) {
+				case 0: //Stop
+					mSwipeRefreshLayout.setRefreshing(false);
+					mSwipeRefreshLayout.setEnabled(true);
+					return true;
+				case 1: //1 Start
+					mSwipeRefreshLayout.setRefreshing(true);
+					mSwipeRefreshLayout.setEnabled(false);
+					return true;
+				default:
+					return false;
 			}
-		});
+		}
+	});
 	/**
 	 * FAB
 	 */
@@ -121,7 +121,8 @@ public class MainActivity extends AppCompatActivity implements
 					if (!DatabaseService.getInstance().getListById(null).contains(item)) {
 						DatabaseService.getInstance().addItem(i, item);//This is the original list
 						//TODO: Use userLearnedSelection from settings
-						if (!DatabaseService.userLearnedSelection) i++;//Fixing exampleAdapter for new position :-)
+						if (!DatabaseService.userLearnedSelection)
+							i++;//Fixing exampleAdapter for new position :-)
 						mAdapter.addItem(i, item);//Adapter's list is a copy, to animate the item you must call addItem on the new position
 						Log.d(TAG, "Added New " + item.getTitle());
 
@@ -290,7 +291,7 @@ public class MainActivity extends AppCompatActivity implements
 					getString(R.string.about_title),
 					getString(R.string.about_body,
 							Utils.getVersionName(this),
-							Utils.getVersionCode(this)) )
+							Utils.getVersionCode(this)))
 					.show(getFragmentManager(), MessageDialog.TAG);
 			return true;
 		}
@@ -302,7 +303,7 @@ public class MainActivity extends AppCompatActivity implements
 	 * Handling RecyclerView when empty.
 	 * <br/><br/>
 	 * <b>Note:</b> The order how the 3 Views (RecyclerView, EmptyView, FastScroller)
-	 *   are placed in the Layout is important!
+	 * are placed in the Layout is important!
 	 */
 	private void updateEmptyView() {
 		FastScroller fastScroller = (FastScroller) findViewById(R.id.fast_scroller);
@@ -368,7 +369,7 @@ public class MainActivity extends AppCompatActivity implements
 			Log.d(TAG, "onListItemLongClick actionMode activated!");
 			mActionMode = startSupportActionMode(this);
 		}
-		Toast.makeText(this, "ImageClick or LongClick on "+mAdapter.getItem(position).getTitle(), Toast.LENGTH_SHORT).show();
+		Toast.makeText(this, "ImageClick or LongClick on " + mAdapter.getItem(position).getTitle(), Toast.LENGTH_SHORT).show();
 		toggleSelection(position);
 	}
 
@@ -388,7 +389,7 @@ public class MainActivity extends AppCompatActivity implements
 			Log.d(TAG, "toggleSelection finish the actionMode");
 			mActionMode.finish();
 		} else {
-			Log.d(TAG, "toggleSelection update title after selection count="+count);
+			Log.d(TAG, "toggleSelection update title after selection count=" + count);
 			setContextTitle(count);
 			mActionMode.invalidate();
 		}
@@ -466,7 +467,7 @@ public class MainActivity extends AppCompatActivity implements
 							}
 						});
 				mSnackBar.show();
-				mAdapter.startUndoTimer(7000L+200L, this);//+200: Using Snackbar, user can still click on the action button while bar is dismissing for a fraction of time
+				mAdapter.startUndoTimer(7000L + 200L, this);//+200: Using Snackbar, user can still click on the action button while bar is dismissing for a fraction of time
 				mSwipeHandler.sendEmptyMessage(1);
 				mSwipeHandler.sendEmptyMessageDelayed(0, 7000L);
 				mActionMode.finish();
@@ -492,6 +493,7 @@ public class MainActivity extends AppCompatActivity implements
 
 	/**
 	 * Utility method called from MainActivity on BackPressed
+	 *
 	 * @return true if ActionMode was active (in case it is also terminated), false otherwise
 	 */
 	public boolean destroyActionModeIfNeeded() {

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MainActivity.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MainActivity.java
@@ -36,7 +36,8 @@ import eu.davidea.utils.Utils;
 public class MainActivity extends AppCompatActivity implements
 		ActionMode.Callback, EditItemDialog.OnEditItemListener,
 		SearchView.OnQueryTextListener,
-		FlexibleAdapter.OnUpdateListener,
+		FlexibleAdapter.OnLoadCompleteListener,
+		FlexibleAdapter.OnDeleteCompleteListener,
 		ExampleAdapter.OnItemClickListener {
 
 	public static final String TAG = MainActivity.class.getSimpleName();

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MainActivity.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MainActivity.java
@@ -466,7 +466,7 @@ public class MainActivity extends AppCompatActivity implements
 							}
 						});
 				mSnackBar.show();
-				mAdapter.startUndoTimer(7000L+200L);//+200: Using Snackbar, user can still click on the action button while bar is dismissing for a fraction of time
+				mAdapter.startUndoTimer(7000L+200L, this);//+200: Using Snackbar, user can still click on the action button while bar is dismissing for a fraction of time
 				mSwipeHandler.sendEmptyMessage(1);
 				mSwipeHandler.sendEmptyMessageDelayed(0, 7000L);
 				mActionMode.finish();

--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -48,7 +48,6 @@ public abstract class FlexibleAdapter<VH extends RecyclerView.ViewHolder, T> ext
     protected OnUpdateListener mUpdateListener;
 
     protected OnLoadCompleteListener onLoadCompleteListener;
-    protected OnDeleteCompleteListener onDeleteCompleteListener;
 
     public FlexibleAdapter() {
     }
@@ -314,7 +313,7 @@ public abstract class FlexibleAdapter<VH extends RecyclerView.ViewHolder, T> ext
      * Convenience method to start Undo timer with default timeout of 5''
      */
     public void startUndoTimer() {
-        startUndoTimer(0);
+        startUndoTimer(0, null);
     }
 
     /**
@@ -322,11 +321,28 @@ public abstract class FlexibleAdapter<VH extends RecyclerView.ViewHolder, T> ext
      *
      * @param timeout Custom timeout
      */
+    @Deprecated
     public void startUndoTimer(long timeout) {
         mHandler = new Handler(Looper.getMainLooper(), new Handler.Callback() {
             public boolean handleMessage(Message message) {
                 if (mUpdateListener != null) mUpdateListener.onDeleteConfirmed();
-                if (onDeleteCompleteListener != null) onDeleteCompleteListener.onDeleteConfirmed();
+                emptyBin();
+                return true;
+            }
+        });
+        mHandler.sendMessageDelayed(Message.obtain(mHandler), timeout > 0 ? timeout : UNDO_TIMEOUT);
+    }
+
+    /**
+     * Start Undo timer with custom timeout
+     *
+     * @param listener delete listener called after timeout
+     * @param timeout  Custom timeout
+     */
+    public void startUndoTimer(long timeout, final OnDeleteCompleteListener listener) {
+        mHandler = new Handler(Looper.getMainLooper(), new Handler.Callback() {
+            public boolean handleMessage(Message message) {
+                if (listener != null) listener.onDeleteConfirmed();
                 emptyBin();
                 return true;
             }

--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -17,446 +17,482 @@ import java.util.Locale;
 /**
  * This class provides a set of standard methods to handle changes on the data set
  * such as adding, removing, moving an item.
- * 
+ * <p/>
  * Remember to call {@link RecyclerView#scheduleLayoutAnimation()} after adding or
  * removing an item from the Adapter when the activity is paused.
- * 
+ * <p/>
  * <strong>VH</strong> is your implementation of {@link RecyclerView.ViewHolder}.
  * <strong>T</strong> is your domain object containing the data.
- * 
+ *
  * @author Davide Steduto
  */
 public abstract class FlexibleAdapter<VH extends RecyclerView.ViewHolder, T> extends SelectableAdapter<VH> {
-	
-	private static final String TAG = FlexibleAdapter.class.getSimpleName();
-	public static final long UNDO_TIMEOUT = 5000L;
 
-	/**
-	 * Lock object used to modify the content of {@link #mItems}.
-	 * Any write operation performed on the list items should be synchronized on this lock.
-	 */
-	private final Object mLock = new Object();
+    private static final String TAG = FlexibleAdapter.class.getSimpleName();
+    public static final long UNDO_TIMEOUT = 5000L;
 
-	protected List<T> mItems;
-	protected List<T> mDeletedItems;
-	protected List<Integer> mOriginalPosition;
-	//Searchable fields
-	protected static String mSearchText; //Static: It can exist only 1 searchText
+    /**
+     * Lock object used to modify the content of {@link #mItems}.
+     * Any write operation performed on the list items should be synchronized on this lock.
+     */
+    private final Object mLock = new Object();
 
-	protected Handler mHandler;
+    protected List<T> mItems;
+    protected List<T> mDeletedItems;
+    protected List<Integer> mOriginalPosition;
+    //Searchable fields
+    protected static String mSearchText; //Static: It can exist only 1 searchText
 
-	protected OnLoadCompleteListener onLoadCompleteListener;
-	protected OnDeleteCompleteListener onDeleteCompleteListener;
+    protected Handler mHandler;
 
-	public FlexibleAdapter() {
-	}
+    protected OnUpdateListener mUpdateListener;
 
-	/**
-	 * Convenience method to call {@link #updateDataSet(String)} with {@link null} as param.
-	 */
-	public void updateDataSet() {
-		updateDataSet(null);
-	}
-	/**
-	 * This method will refresh the entire DataSet content.<br/>
-	 * The parameter is useful to filter the type of the DataSet.<br/>
-	 * Pass null value in case not used.
-	 * 
-	 * @param param A custom parameter to filter the type of the DataSet
-	 */
-	public abstract void updateDataSet(String param);
+    protected OnLoadCompleteListener onLoadCompleteListener;
+    protected OnDeleteCompleteListener onDeleteCompleteListener;
 
-	/**
-	 * This method execute {@link #updateDataSet(String)} asynchronously
-	 * with {@link FilterAsyncTask}.<br/><br/>
-	 * <b>Note:</b> {@link #notifyDataSetChanged()} is automatically called at the end of the process.
-	 *
-	 * @param param A custom parameter to filter the DataSet
-	 */
-	public void updateDataSetAsync(String param) {
-		//Synchronous
-		if (onLoadCompleteListener == null) {
-			Log.w(TAG, "OnUpdateListener is not initialized. updateDataSetAsync is not using FilterAsyncTask!");
-			updateDataSet(param);
-			notifyDataSetChanged();
-			return;
-		}
-		//Asynchronous
-		new FilterAsyncTask().execute(param);
-	}
-	
-	/**
-	 * Returns the custom object "Item".
-	 *
-	 * @param position The position of the item in the list
-	 * @return The custom "Item" object or null if item not found
-	 */
-	public T getItem(int position) {
-		if (position < 0 || position >= mItems.size()) return null;
-		return mItems.get(position);
-	}
-	
-	/**
-	 * Retrieve the position of the Item in the Adapter
-	 *
-	 * @param item The item
-	 * @return The position in the Adapter if found, -1 otherwise
-	 */
-	public int getPositionForItem(T item) {
-		return mItems != null && mItems.size() > 0 ? mItems.indexOf(item) : -1;
-	}
+    public FlexibleAdapter() {
+    }
 
-	public boolean contains(T item) {
-		return mItems != null && mItems.contains(item);
-	}
-	
-	@Override
-	public abstract VH onCreateViewHolder(ViewGroup parent, int viewType);
-	
-	@Override
-	public abstract void onBindViewHolder(VH holder, final int position);
+    /**
+     * Constructor for Asynchronous loading.<br/>
+     * Experimental: not working very well, it might be slow.
+     *
+     * @param listener {@link OnUpdateListener}
+     */
+    @Deprecated
+    public FlexibleAdapter(Object listener) {
+        if (listener instanceof OnUpdateListener)
+            this.mUpdateListener = (OnUpdateListener) listener;
+        else
+            Log.w(TAG, "Listener is not an instance of OnUpdateListener!");
+    }
 
-	@Override
-	public int getItemCount() {
-		return mItems != null ? mItems.size() : 0;
-	}
-	
-	public void updateItem(int position, T item) {
-		if (position < 0) return;
-		synchronized (mLock) {
-			mItems.set(position, item);
-		}
-		Log.v(TAG, "updateItem notifyItemChanged on position " + position);
-		notifyItemChanged(position);
-	}
+    /**
+     * Convenience method to call {@link #updateDataSet(String)} with {@link null} as param.
+     */
 
-	/**
-	 * Insert given Item at position or Add Item at last position.
-	 *
-	 * @param position Position of the item to add
-	 * @param item The item to add
-	 */
-	public void addItem(int position, T item) {
-		if (position < 0) return;
+    public void updateDataSet() {
+        updateDataSet(null);
+    }
 
-		//Insert Item
-		if (position < mItems.size()) {
-			Log.v(TAG, "addItem notifyItemInserted on position " + position);
-			synchronized (mLock) {
-				mItems.add(position, item);
-			}
+    /**
+     * This method will refresh the entire DataSet content.<br/>
+     * The parameter is useful to filter the type of the DataSet.<br/>
+     * Pass null value in case not used.
+     *
+     * @param param A custom parameter to filter the type of the DataSet
+     */
+    public abstract void updateDataSet(String param);
 
-		//Add Item at the last position
-		} else {
-			Log.v(TAG, "addItem notifyItemInserted on last position");
-			synchronized (mLock) {
-				mItems.add(item);
-				position = mItems.size();
-			}
-		}
+    /**
+     * This method execute {@link #updateDataSet(String)} asynchronously
+     * with {@link FilterAsyncTask}.<br/><br/>
+     * <b>Note:</b> {@link #notifyDataSetChanged()} is automatically called at the end of the process.
+     *
+     * @param param A custom parameter to filter the DataSet
+     */
+    public void updateDataSetAsync(String param) {
+        //Synchronous
+        if ((mUpdateListener != null) || (onLoadCompleteListener == null)) {
+            Log.w(TAG, "OnUpdateListener is not initialized. updateDataSetAsync is not using FilterAsyncTask!");
+            updateDataSet(param);
+            notifyDataSetChanged();
+            return;
+        }
+        //Asynchronous
+        new FilterAsyncTask().execute(param);
+    }
 
-		notifyItemInserted(position);
-	}
+    /**
+     * Returns the custom object "Item".
+     *
+     * @param position The position of the item in the list
+     * @return The custom "Item" object or null if item not found
+     */
+    public T getItem(int position) {
+        if (position < 0 || position >= mItems.size()) return null;
+        return mItems.get(position);
+    }
+
+    /**
+     * Retrieve the position of the Item in the Adapter
+     *
+     * @param item The item
+     * @return The position in the Adapter if found, -1 otherwise
+     */
+    public int getPositionForItem(T item) {
+        return mItems != null && mItems.size() > 0 ? mItems.indexOf(item) : -1;
+    }
+
+    public boolean contains(T item) {
+        return mItems != null && mItems.contains(item);
+    }
+
+    @Override
+    public abstract VH onCreateViewHolder(ViewGroup parent, int viewType);
+
+    @Override
+    public abstract void onBindViewHolder(VH holder, final int position);
+
+    @Override
+    public int getItemCount() {
+        return mItems != null ? mItems.size() : 0;
+    }
+
+    public void updateItem(int position, T item) {
+        if (position < 0) return;
+        synchronized (mLock) {
+            mItems.set(position, item);
+        }
+        Log.v(TAG, "updateItem notifyItemChanged on position " + position);
+        notifyItemChanged(position);
+    }
+
+    /**
+     * Insert given Item at position or Add Item at last position.
+     *
+     * @param position Position of the item to add
+     * @param item     The item to add
+     */
+    public void addItem(int position, T item) {
+        if (position < 0) return;
+
+        //Insert Item
+        if (position < mItems.size()) {
+            Log.v(TAG, "addItem notifyItemInserted on position " + position);
+            synchronized (mLock) {
+                mItems.add(position, item);
+            }
+
+            //Add Item at the last position
+        } else {
+            Log.v(TAG, "addItem notifyItemInserted on last position");
+            synchronized (mLock) {
+                mItems.add(item);
+                position = mItems.size();
+            }
+        }
+
+        notifyItemInserted(position);
+    }
 
 	/* DELETE ITEMS METHODS */
 
-	/**
-	 * The item is retained in a list for an eventual Undo.
-	 *
-	 * @param position The position of item to remove
-	 * @see #startUndoTimer()
-	 * @see #restoreDeletedItems()
-	 * @see #emptyBin()
-	 */
-	public void removeItem(int position) {
-		if (position < 0) return;
-		if (position < mItems.size()) {
-			Log.v(TAG, "removeItem notifyItemRemoved on position " + position);
-			synchronized (mLock) {
-				saveDeletedItem(position, mItems.remove(position));
-			}
-			notifyItemRemoved(position);
-		} else {
-			Log.w(TAG, "removeItem WARNING! Position OutOfBound! Review the position to remove!");
-		}
-	}
+    /**
+     * The item is retained in a list for an eventual Undo.
+     *
+     * @param position The position of item to remove
+     * @see #startUndoTimer()
+     * @see #restoreDeletedItems()
+     * @see #emptyBin()
+     */
+    public void removeItem(int position) {
+        if (position < 0) return;
+        if (position < mItems.size()) {
+            Log.v(TAG, "removeItem notifyItemRemoved on position " + position);
+            synchronized (mLock) {
+                saveDeletedItem(position, mItems.remove(position));
+            }
+            notifyItemRemoved(position);
+        } else {
+            Log.w(TAG, "removeItem WARNING! Position OutOfBound! Review the position to remove!");
+        }
+    }
 
-	/**
-	 * Every item is retained in a list for an eventual Undo.
-	 *
-	 * @param selectedPositions List of item positions to remove
-	 * @see #startUndoTimer()
-	 * @see #restoreDeletedItems()
-	 * @see #emptyBin()
-	 */
-	public void removeItems(List<Integer> selectedPositions) {
-		Log.v(TAG, "removeItems reverse Sorting positions --------------");
-		// Reverse-sort the list
-		Collections.sort(selectedPositions, new Comparator<Integer>() {
-			@Override
-			public int compare(Integer lhs, Integer rhs) {
-				return rhs - lhs;
-			}
-		});
+    /**
+     * Every item is retained in a list for an eventual Undo.
+     *
+     * @param selectedPositions List of item positions to remove
+     * @see #startUndoTimer()
+     * @see #restoreDeletedItems()
+     * @see #emptyBin()
+     */
+    public void removeItems(List<Integer> selectedPositions) {
+        Log.v(TAG, "removeItems reverse Sorting positions --------------");
+        // Reverse-sort the list
+        Collections.sort(selectedPositions, new Comparator<Integer>() {
+            @Override
+            public int compare(Integer lhs, Integer rhs) {
+                return rhs - lhs;
+            }
+        });
 
-		// Split the list in ranges
-		while (!selectedPositions.isEmpty()) {
-			if (selectedPositions.size() == 1) {
-				removeItem(selectedPositions.get(0));
-				//Align the selection list when removing the item
-				selectedPositions.remove(0);
-			} else {
-				int count = 1;
-				while (selectedPositions.size() > count && selectedPositions.get(count).equals(selectedPositions.get(count - 1) - 1)) {
-					++count;
-				}
+        // Split the list in ranges
+        while (!selectedPositions.isEmpty()) {
+            if (selectedPositions.size() == 1) {
+                removeItem(selectedPositions.get(0));
+                //Align the selection list when removing the item
+                selectedPositions.remove(0);
+            } else {
+                int count = 1;
+                while (selectedPositions.size() > count && selectedPositions.get(count).equals(selectedPositions.get(count - 1) - 1)) {
+                    ++count;
+                }
 
-				if (count == 1) {
-					removeItem(selectedPositions.get(0));
-				} else {
-					removeRange(selectedPositions.get(count - 1), count);
-				}
+                if (count == 1) {
+                    removeItem(selectedPositions.get(0));
+                } else {
+                    removeRange(selectedPositions.get(count - 1), count);
+                }
 
-				for (int i = 0; i < count; ++i) {
-					selectedPositions.remove(0);
-				}
-			}
-			Log.v(TAG, "removeItems current selection " + getSelectedItems());
-		}
-	}
+                for (int i = 0; i < count; ++i) {
+                    selectedPositions.remove(0);
+                }
+            }
+            Log.v(TAG, "removeItems current selection " + getSelectedItems());
+        }
+    }
 
-	private void removeRange(int positionStart, int itemCount) {
-		Log.v(TAG, "removeRange positionStart=" + positionStart + " itemCount=" + itemCount);
-		for (int i = 0; i < itemCount; ++i) {
-			synchronized (mLock) {
-				saveDeletedItem(positionStart, mItems.remove(positionStart));
-			}
-		}
-		Log.v(TAG, "removeRange notifyItemRangeRemoved");
-		notifyItemRangeRemoved(positionStart, itemCount);
-	}
+    private void removeRange(int positionStart, int itemCount) {
+        Log.v(TAG, "removeRange positionStart=" + positionStart + " itemCount=" + itemCount);
+        for (int i = 0; i < itemCount; ++i) {
+            synchronized (mLock) {
+                saveDeletedItem(positionStart, mItems.remove(positionStart));
+            }
+        }
+        Log.v(TAG, "removeRange notifyItemRangeRemoved");
+        notifyItemRangeRemoved(positionStart, itemCount);
+    }
 
 	/* UNDO METHODS */
 
-	/**
-	 * Save temporary Items for an eventual Undo.
-	 *
-	 * @param position The position of the item to retain.
-	 */
-	public void saveDeletedItem(int position, T item) {
-		if (mDeletedItems == null) {
-			mDeletedItems = new ArrayList<T>();
-			mOriginalPosition = new ArrayList<Integer>();
-		}
-		Log.v(TAG, "Recycled " + getItem(position) + " on position=" + position);
-		mDeletedItems.add(item);
-		mOriginalPosition.add(position);
-	}
+    /**
+     * Save temporary Items for an eventual Undo.
+     *
+     * @param position The position of the item to retain.
+     */
+    public void saveDeletedItem(int position, T item) {
+        if (mDeletedItems == null) {
+            mDeletedItems = new ArrayList<T>();
+            mOriginalPosition = new ArrayList<Integer>();
+        }
+        Log.v(TAG, "Recycled " + getItem(position) + " on position=" + position);
+        mDeletedItems.add(item);
+        mOriginalPosition.add(position);
+    }
 
-	/**
-	 * @return The list of deleted items
-	 */
-	public List<T> getDeletedItems() {
-		return mDeletedItems;
-	}
+    /**
+     * @return The list of deleted items
+     */
+    public List<T> getDeletedItems() {
+        return mDeletedItems;
+    }
 
-	public boolean isRestoreInTime() {
-		return mDeletedItems != null && mDeletedItems.size() > 0;
-	}
+    public boolean isRestoreInTime() {
+        return mDeletedItems != null && mDeletedItems.size() > 0;
+    }
 
-	/**
-	 * Restore items just removed.<br/>
-	 * <b>NOTE:</b> If filter is active, only items that match that filter will be shown(restored).
-	 */
-	public void restoreDeletedItems() {
-		stopUndoTimer();
-		//Reverse insert (list was reverse ordered on Delete)
-		for (int i = mOriginalPosition.size()-1; i >= 0; i--) {
-			T item = mDeletedItems.get(i);
-			//Avoid to restore(show) Items not filtered by the current filter
-			if (hasSearchText() && !filterObject(item, getSearchText()))
-				continue;
-			addItem(mOriginalPosition.get(i), item);
-		}
-		emptyBin();
-	}
+    /**
+     * Restore items just removed.<br/>
+     * <b>NOTE:</b> If filter is active, only items that match that filter will be shown(restored).
+     */
+    public void restoreDeletedItems() {
+        stopUndoTimer();
+        //Reverse insert (list was reverse ordered on Delete)
+        for (int i = mOriginalPosition.size() - 1; i >= 0; i--) {
+            T item = mDeletedItems.get(i);
+            //Avoid to restore(show) Items not filtered by the current filter
+            if (hasSearchText() && !filterObject(item, getSearchText()))
+                continue;
+            addItem(mOriginalPosition.get(i), item);
+        }
+        emptyBin();
+    }
 
-	/**
-	 * Clean memory from items just removed.<br/>
-	 * <b>Note:</b> This method is automatically called after timer is over and after a restoration.
-	 */
-	public synchronized void emptyBin() {
-		if (mDeletedItems != null) {
-			mDeletedItems.clear();
-			mOriginalPosition.clear();
-		}
-	}
+    /**
+     * Clean memory from items just removed.<br/>
+     * <b>Note:</b> This method is automatically called after timer is over and after a restoration.
+     */
+    public synchronized void emptyBin() {
+        if (mDeletedItems != null) {
+            mDeletedItems.clear();
+            mOriginalPosition.clear();
+        }
+    }
 
-	/**
-	 * Convenience method to start Undo timer with default timeout of 5''
-	 */
-	public void startUndoTimer() {
-		startUndoTimer(0);
-	}
+    /**
+     * Convenience method to start Undo timer with default timeout of 5''
+     */
+    public void startUndoTimer() {
+        startUndoTimer(0);
+    }
 
-	/**
-	 * Start Undo timer with custom timeout
-	 *
-	 * @param timeout Custom timeout
-	 */
-	public void startUndoTimer(long timeout) {
-		mHandler = new Handler(Looper.getMainLooper(), new Handler.Callback() {
-				public boolean handleMessage(Message message) {
-					if (onDeleteCompleteListener != null) onDeleteCompleteListener.onDeleteConfirmed();
-					emptyBin();
-					return true;
-				}
-			});
-		mHandler.sendMessageDelayed(Message.obtain(mHandler), timeout > 0 ? timeout : UNDO_TIMEOUT);
-	}
+    /**
+     * Start Undo timer with custom timeout
+     *
+     * @param timeout Custom timeout
+     */
+    public void startUndoTimer(long timeout) {
+        mHandler = new Handler(Looper.getMainLooper(), new Handler.Callback() {
+            public boolean handleMessage(Message message) {
+                if (mUpdateListener != null) mUpdateListener.onDeleteConfirmed();
+                if (onDeleteCompleteListener != null) onDeleteCompleteListener.onDeleteConfirmed();
+                emptyBin();
+                return true;
+            }
+        });
+        mHandler.sendMessageDelayed(Message.obtain(mHandler), timeout > 0 ? timeout : UNDO_TIMEOUT);
+    }
 
-	/**
-	 * Stop Undo timer.
-	 * <br/><b>Note:</b> This method is automatically called in case of restoration.
-	 */
-	private void stopUndoTimer() {
-		if (mHandler != null) {
-			mHandler.removeCallbacksAndMessages(null);
-			mHandler = null;
-		}
-	}
+    /**
+     * Stop Undo timer.
+     * <br/><b>Note:</b> This method is automatically called in case of restoration.
+     */
+    private void stopUndoTimer() {
+        if (mHandler != null) {
+            mHandler.removeCallbacksAndMessages(null);
+            mHandler = null;
+        }
+    }
 
-	public static boolean hasSearchText() {
-		return mSearchText != null && mSearchText.length() > 0;
-	}
+    public static boolean hasSearchText() {
+        return mSearchText != null && mSearchText.length() > 0;
+    }
 
-	public static String getSearchText() {
-		return mSearchText;
-	}
+    public static String getSearchText() {
+        return mSearchText;
+    }
 
-	public static void setSearchText(String searchText) {
-		if (searchText != null)
-			mSearchText = searchText.trim().toLowerCase(Locale.getDefault());
-		else mSearchText = "";
-	}
+    public static void setSearchText(String searchText) {
+        if (searchText != null)
+            mSearchText = searchText.trim().toLowerCase(Locale.getDefault());
+        else mSearchText = "";
+    }
 
-	/**
-	 * Filter the provided list with the search text previously set
-	 * with {@link #setSearchText(String)}.
-	 * <br/><br/>
-	 * <b>Note: </b>
-	 * <br/>- This method calls {@link #filterObject(T, String)}.
-	 * <br/>- If search text is empty or null, the provided list is the current list.
-	 * <br/>- Any pending deleted items are always filtered out.
-	 * <br/>- Original positions of deleted items are recalculated.
-	 *
-	 * @param unfilteredItems The list to filter
-	 * @see #filterObject(Object, String)
-	 */
-	protected synchronized void filterItems(List<T> unfilteredItems) {
-		// NOTE: In case user has deleted some items and he changes or applies a filter while
-		// deletion is pending (Undo started), in order to be consistent, we need to recalculate
-		// the new position in the new list and finally skip those items to avoid they are shown!
-		if (hasSearchText()) {
-			mItems = new ArrayList<T>(); //with filter
-			int newOriginalPosition = -1, oldOriginalPosition = -1;
-			for (T item : unfilteredItems) {
-				if (filterObject(item, getSearchText())) {
-					if (mDeletedItems != null && mDeletedItems.contains(item)) {
-						int index = mDeletedItems.indexOf(item);
-						//Calculate new original position: skip counting position if item was deleted in range
-						if (mOriginalPosition.get(index) != oldOriginalPosition) {
-							newOriginalPosition++;
-							oldOriginalPosition = mOriginalPosition.get(index);
-						}
-						mOriginalPosition.set(index, newOriginalPosition + mItems.size());
-					} else {
-						mItems.add(item);
-					}
-				}
-			}
-		} else {
-			mItems = unfilteredItems; //with no filter
-			if (mDeletedItems != null && !mDeletedItems.isEmpty()) {
-				mOriginalPosition = new ArrayList<Integer>(mDeletedItems.size());
-				for (T item : mDeletedItems) {
-					mOriginalPosition.add(mItems.indexOf(item));
-				}
-				mItems.removeAll(mDeletedItems);
-			}
-		}
-	}
+    /**
+     * Filter the provided list with the search text previously set
+     * with {@link #setSearchText(String)}.
+     * <br/><br/>
+     * <b>Note: </b>
+     * <br/>- This method calls {@link #filterObject(T, String)}.
+     * <br/>- If search text is empty or null, the provided list is the current list.
+     * <br/>- Any pending deleted items are always filtered out.
+     * <br/>- Original positions of deleted items are recalculated.
+     *
+     * @param unfilteredItems The list to filter
+     * @see #filterObject(Object, String)
+     */
+    protected synchronized void filterItems(List<T> unfilteredItems) {
+        // NOTE: In case user has deleted some items and he changes or applies a filter while
+        // deletion is pending (Undo started), in order to be consistent, we need to recalculate
+        // the new position in the new list and finally skip those items to avoid they are shown!
+        if (hasSearchText()) {
+            mItems = new ArrayList<T>(); //with filter
+            int newOriginalPosition = -1, oldOriginalPosition = -1;
+            for (T item : unfilteredItems) {
+                if (filterObject(item, getSearchText())) {
+                    if (mDeletedItems != null && mDeletedItems.contains(item)) {
+                        int index = mDeletedItems.indexOf(item);
+                        //Calculate new original position: skip counting position if item was deleted in range
+                        if (mOriginalPosition.get(index) != oldOriginalPosition) {
+                            newOriginalPosition++;
+                            oldOriginalPosition = mOriginalPosition.get(index);
+                        }
+                        mOriginalPosition.set(index, newOriginalPosition + mItems.size());
+                    } else {
+                        mItems.add(item);
+                    }
+                }
+            }
+        } else {
+            mItems = unfilteredItems; //with no filter
+            if (mDeletedItems != null && !mDeletedItems.isEmpty()) {
+                mOriginalPosition = new ArrayList<Integer>(mDeletedItems.size());
+                for (T item : mDeletedItems) {
+                    mOriginalPosition.add(mItems.indexOf(item));
+                }
+                mItems.removeAll(mDeletedItems);
+            }
+        }
+    }
 
-	/**
-	 * DEFAULT IMPLEMENTATION, OVERRIDE TO HAVE OWN FILTER!
-	 *
-	 * <br/><br/>
-	 * Performs filtering on the provided object and returns true, if the object should be in the filtered collection,
-	 * or false if it shouldn't.
-	 *
-	 * @param myObject The object to be inspected
-	 * @param constraint Constraint, that the object has to fulfil
-	 * @return true, if the object should be in the filteredResult, false otherwise
-	 */
-	protected boolean filterObject(T myObject, String constraint) {
-		final String valueText = myObject.toString().toLowerCase();
+    /**
+     * DEFAULT IMPLEMENTATION, OVERRIDE TO HAVE OWN FILTER!
+     * <p/>
+     * <br/><br/>
+     * Performs filtering on the provided object and returns true, if the object should be in the filtered collection,
+     * or false if it shouldn't.
+     *
+     * @param myObject   The object to be inspected
+     * @param constraint Constraint, that the object has to fulfil
+     * @return true, if the object should be in the filteredResult, false otherwise
+     */
+    protected boolean filterObject(T myObject, String constraint) {
+        final String valueText = myObject.toString().toLowerCase();
 
-		//First match against the whole, non-splitted value
-		if (valueText.startsWith(constraint)) {
-			return true;
-		} else {
-			final String[] words = valueText.split(" ");
+        //First match against the whole, non-splitted value
+        if (valueText.startsWith(constraint)) {
+            return true;
+        } else {
+            final String[] words = valueText.split(" ");
 
-			//Start at index 0, in case valueText starts with space(s)
-			for (String word : words) {
-				if (word.startsWith(constraint)) {
-					return true;
-				}
-			}
-		}
-		//No match, so don't add to collection
-		return false;
-	}
+            //Start at index 0, in case valueText starts with space(s)
+            for (String word : words) {
+                if (word.startsWith(constraint)) {
+                    return true;
+                }
+            }
+        }
+        //No match, so don't add to collection
+        return false;
+    }
 
-	public class FilterAsyncTask extends AsyncTask<String, Void, Void> {
+    public class FilterAsyncTask extends AsyncTask<String, Void, Void> {
 
-		private final String TAG = FilterAsyncTask.class.getSimpleName();
+        private final String TAG = FilterAsyncTask.class.getSimpleName();
 
-		@Override
-		protected Void doInBackground(String... params) {
-			//Log.v(TAG, "doInBackground - started FilterAsyncTask!");
-			updateDataSet(params[0]);
-			//Log.v(TAG, "doInBackground - ended FilterAsyncTask!");
-			return null;
-		}
+        @Override
+        protected Void doInBackground(String... params) {
+            //Log.v(TAG, "doInBackground - started FilterAsyncTask!");
+            updateDataSet(params[0]);
+            //Log.v(TAG, "doInBackground - ended FilterAsyncTask!");
+            return null;
+        }
 
-		@Override
-		protected void onPostExecute(Void result) {
-			super.onPostExecute(result);
-			onLoadCompleteListener.onLoadComplete();
-			notifyDataSetChanged();
-		}
-	}
+        @Override
+        protected void onPostExecute(Void result) {
+            super.onPostExecute(result);
+            onLoadCompleteListener.onLoadComplete();
+            notifyDataSetChanged();
+        }
+    }
 
-	public interface OnDeleteCompleteListener {
+    @Deprecated
+    public interface OnUpdateListener {
+        /**
+         * Called when Async load is completed.
+         */
+        void onLoadComplete();
 
-		/**
-		 * Due to Java Generic, it's too complicated and not
-		 * well manageable if we return the List&lt;T&gt; object.<br/>
-		 * To get deleted items, use {@link #getDeletedItems()} from the
-		 * implementation of this method.
-		 */
-		void onDeleteConfirmed();
+        /**
+         * Due to Java Generic, it's too complicated and not
+         * well manageable if we return the List&lt;T&gt; object.<br/>
+         * To get deleted items, use {@link #getDeletedItems()} from the
+         * implementation of this method.
+         */
+        void onDeleteConfirmed();
+        //void onProgressUpdate(int progress);
+    }
 
-	}
+    public interface OnDeleteCompleteListener {
 
-	public interface OnLoadCompleteListener {
+        /**
+         * Due to Java Generic, it's too complicated and not
+         * well manageable if we return the List&lt;T&gt; object.<br/>
+         * To get deleted items, use {@link #getDeletedItems()} from the
+         * implementation of this method.
+         */
+        void onDeleteConfirmed();
 
-		/**
-		 * Called when Async load is completed.
-		 */
-		void onLoadComplete();
+    }
 
-	}
+    public interface OnLoadCompleteListener {
+
+        /**
+         * Called when Async load is completed.
+         */
+        void onLoadComplete();
+
+    }
 
 }

--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/SelectableAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/SelectableAdapter.java
@@ -81,13 +81,13 @@ public abstract class SelectableAdapter<VH extends RecyclerView.ViewHolder> exte
 	/**
 	 * Toggle the selection status of the item at a given position.<br/>
 	 * The behaviour depends on the selection mode previously set with {@link #setMode}.
-	 *
+	 * <p/>
 	 * <br/><br/>
 	 * Optionally the item can be invalidated.<br/>
 	 * However it is preferable to set <i>false</i> and to handle the Activated/Selected State of
 	 * the ItemView in the Click events of the ViewHolder after the selection is registered and
 	 * up to date: Very Useful if the item has views with own animation to perform!
-	 *
+	 * <p/>
 	 * <br/><br/>
 	 * <b>Usage:</b>
 	 * <ul>
@@ -100,9 +100,9 @@ public abstract class SelectableAdapter<VH extends RecyclerView.ViewHolder> exte
 	 * <li>In <i>onBindViewHolder</i>, adjust the selection status: <i>holder.itemView.setActivated(isSelected(position));</i></li>
 	 * <li>If <i>invalidate</i> is set true, {@link #notifyItemChanged} is called and {@link #onBindViewHolder} will be automatically called
 	 * afterwards overriding any animation in the ItemView!</li>
-	 *</ul>T
+	 * </ul>T
 	 *
-	 * @param position Position of the item to toggle the selection status for.
+	 * @param position   Position of the item to toggle the selection status for.
 	 * @param invalidate Boolean to indicate if the row must be invalidated and item rebinded.
 	 */
 	public void toggleSelection(int position, boolean invalidate) {
@@ -130,6 +130,7 @@ public abstract class SelectableAdapter<VH extends RecyclerView.ViewHolder> exte
 	public void selectAll() {
 		selectAll(-1);
 	}
+
 	/**
 	 * Add the selection status for all items.
 	 * The selector container is sequentially filled with All items positions.
@@ -143,7 +144,7 @@ public abstract class SelectableAdapter<VH extends RecyclerView.ViewHolder> exte
 		for (int i = 0; i < getItemCount(); i++) {
 			if (getItemViewType(i) == skipViewType) continue;
 			selectedItems.add(i);
-			Log.v(TAG, "selectAll notifyItemChanged on position "+i);
+			Log.v(TAG, "selectAll notifyItemChanged on position " + i);
 			notifyItemChanged(i);
 		}
 	}
@@ -160,7 +161,7 @@ public abstract class SelectableAdapter<VH extends RecyclerView.ViewHolder> exte
 			//The notification is done only on items that are currently selected.
 			int i = iterator.next();
 			iterator.remove();
-			Log.v(TAG, "clearSelection notifyItemChanged on position "+i);
+			Log.v(TAG, "clearSelection notifyItemChanged on position " + i);
 			notifyItemChanged(i);
 		}
 	}


### PR DESCRIPTION
I've divided the `OnUpdateListener` in two new classes. `OnDeleteCompleteListener` and `OnLoadCompleteListener`.

I think the protected field is enough to use that

**In My Activity/Fragment**
```Java
public class MyActivity extends AppCompatActivity implements FlexibleAdapter.OnDeleteCompleteListener  {

    @Override
    public void onDeleteConfirmed() {
        for (MyDomainClass item : mAdapter.getDeletedItems()) {
            // Delete from Database
        }
    }

}
```
**In My Adapter**
```Java
public class MyRecyclerViewAdapter
        extends FlexibleAdapter<MyViewHolder, MyDomainClass> {

    public RecyclerViewAdapter(FlexibleAdapter.OnDeleteCompleteListener onDeleteCompleteListener) {
            super.onDeleteCompleteListener = onDeleteCompleteListener;
    }

}
```

Another option is force pass it in construction but I don't like that style. Wdyt?