### PR TITLE
Multiple code improvements - squid:S1213, squid:S2325, squid:S1488, squid:S2131

### DIFF
--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/DatabaseService.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/DatabaseService.java
@@ -30,14 +30,6 @@ public class DatabaseService {
 	//Database original items
 	private List<AbstractFlexibleItem> mItems = new ArrayList<AbstractFlexibleItem>();
 
-
-	public static DatabaseService getInstance() {
-		if (mInstance == null) {
-			mInstance = new DatabaseService();
-		}
-		return mInstance;
-	}
-
 	DatabaseService() {
 		HeaderItem header = null;
 		for (int i = 0; i < ITEMS; i++) {
@@ -46,6 +38,13 @@ public class DatabaseService {
 					newExpandableItem(i + 1, header) :
 					newSimpleItem(i + 1, header));
 		}
+	}
+
+	public static DatabaseService getInstance() {
+		if (mInstance == null) {
+			mInstance = new DatabaseService();
+		}
+		return mInstance;
 	}
 
 	public static HeaderItem newHeader(int i) {

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/ExampleAdapter.java
@@ -261,7 +261,7 @@ public class ExampleAdapter extends FlexibleAdapter<AbstractFlexibleItem> {
 	public String onCreateBubbleText(int position) {
 		if (!DatabaseService.userLearnedSelection && position == 0) {//This 'if' is for my example only
 			//TODO FOR YOU: This is the normal line you should use: Usually it's the first letter
-			return ""+position;
+			return Integer.toString(position);
 		}
 		return super.onCreateBubbleText(position);
 	}

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MessageDialog.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/flexibleadapter/MessageDialog.java
@@ -57,10 +57,8 @@ public class MessageDialog extends DialogFragment {
 						dialog.dismiss();
 					}
 				});
-		
-		final AlertDialog dialog = builder.create();
-		
-		return dialog;
+
+		return builder.create();
 	}
 	
 }

--- a/flexible-adapter/src/main/java/eu/davidea/fastscroller/FastScroller.java
+++ b/flexible-adapter/src/main/java/eu/davidea/fastscroller/FastScroller.java
@@ -240,7 +240,7 @@ public class FastScroller extends FrameLayout {
 		}
 	}
 
-	private int getValueInRange(int min, int max, int value) {
+	private static int getValueInRange(int min, int max, int value) {
 		int minimum = Math.max(min, value);
 		return Math.min(minimum, max);
 	}

--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/items/AbstractFlexibleItem.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/items/AbstractFlexibleItem.java
@@ -33,6 +33,8 @@ import eu.davidea.flexibleadapter.FlexibleAdapter;
 public abstract class AbstractFlexibleItem<VH extends RecyclerView.ViewHolder>
 		implements IFlexible<VH> {
 
+	private static final String MAPPING_ILLEGAL_STATE = "If you want FlexibleAdapter creates and binds ViewHolder for you, you must override and implement the method ";
+
 	/* Item flags recognized by the FlexibleAdapter */
 	protected boolean mEnabled = true, mHidden = false,
 			mSelectable = true, mSelected = false,
@@ -123,8 +125,6 @@ public abstract class AbstractFlexibleItem<VH extends RecyclerView.ViewHolder>
 	/*---------------------*/
 	/* VIEW HOLDER METHODS */
 	/*---------------------*/
-
-	private static final String MAPPING_ILLEGAL_STATE = "If you want FlexibleAdapter creates and binds ViewHolder for you, you must override and implement the method ";
 
 //	/**
 //	 * Wrapper of {#getLayoutRes()}.


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2325 - "private" methods that don't access instance data should be "static".
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2325
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
George Kankava