### PR TITLE
squid:S1155 - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -409,7 +409,7 @@ public class FlexibleAdapter<T extends IFlexible>
 	 * @return the global position in the Adapter if found, -1 otherwise
 	 */
 	public int getGlobalPositionOf(@NonNull IFlexible item) {
-		return item != null && mItems != null && mItems.size() > 0 ? mItems.indexOf(item) : -1;
+		return item != null && mItems != null && !mItems.isEmpty() ? mItems.indexOf(item) : -1;
 	}
 
 	/**
@@ -1852,7 +1852,7 @@ public class FlexibleAdapter<T extends IFlexible>
 			restoreInfo.item.setHidden(false);
 		}
 		//Restore selection if requested, before emptyBin
-		if (restoreSelection && mRestoreList.size() > 0) {
+		if (restoreSelection && !mRestoreList.isEmpty()) {
 			if (isExpandable(mRestoreList.get(0).item) || getExpandableOf(mRestoreList.get(0).item) == null) {
 				parentSelected = true;
 			} else {
@@ -1914,7 +1914,7 @@ public class FlexibleAdapter<T extends IFlexible>
 	}
 
 	public boolean isRestoreInTime() {
-		return mRestoreList != null && mRestoreList.size() > 0;
+		return mRestoreList != null && !mRestoreList.isEmpty();
 	}
 
 	/**
@@ -1985,7 +1985,7 @@ public class FlexibleAdapter<T extends IFlexible>
 		//Take a copy of the subItems list
 		List<T> subItems = new ArrayList<T>(expandable.getSubItems());
 		//Remove all children pending removal
-		if (mRestoreList.size() > 0) {
+		if (!mRestoreList.isEmpty()) {
 			subItems.removeAll(getDeletedChildren(expandable));
 		}
 		return subItems;

--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/SelectableAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/SelectableAdapter.java
@@ -239,7 +239,7 @@ public abstract class SelectableAdapter extends RecyclerView.Adapter
 		int positionStart = 0, itemCount = 0;
 		for (int i = 0; i < getItemCount(); i++) {
 			if (isSelectable(i) &&
-					(viewTypesToSelect.size() == 0 || viewTypesToSelect.contains(getItemViewType(i)))) {
+					(viewTypesToSelect.isEmpty() || viewTypesToSelect.contains(getItemViewType(i)))) {
 				mSelectedPositions.add(i);
 				itemCount++;
 			} else {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava