### PR TITLE
squid:S1217 - Thread.run() and Runnable.run() should not be called directly

### DIFF
--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/anim/BaseItemAnimator.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/anim/BaseItemAnimator.java
@@ -132,7 +132,7 @@ public abstract class BaseItemAnimator extends SimpleItemAnimator {
 				View view = moves.get(0).holder.itemView;
 				ViewCompat.postOnAnimationDelayed(view, mover, getRemoveDuration());
 			} else {
-				mover.run();
+				new Thread(mover).start();
 			}
 		}
 		// Next, change stuff, to run in parallel with move animations
@@ -155,7 +155,7 @@ public abstract class BaseItemAnimator extends SimpleItemAnimator {
 				ViewHolder holder = changes.get(0).oldHolder;
 				ViewCompat.postOnAnimationDelayed(holder.itemView, changer, getRemoveDuration());
 			} else {
-				changer.run();
+				new Thread(changer).start();
 			}
 		}
 		// Next, add stuff
@@ -181,7 +181,7 @@ public abstract class BaseItemAnimator extends SimpleItemAnimator {
 				View view = additions.get(0).itemView;
 				ViewCompat.postOnAnimationDelayed(view, adder, totalDelay);
 			} else {
-				adder.run();
+				new Thread(adder).start();
 			}
 		}
 	}

--- a/flexible-adapter-app/src/main/java/eu/davidea/examples/anim/PendingItemAnimator.java
+++ b/flexible-adapter-app/src/main/java/eu/davidea/examples/anim/PendingItemAnimator.java
@@ -109,7 +109,7 @@ public abstract class PendingItemAnimator<H extends ViewHolder> extends SimpleIt
 				View view = mMoves.get(0).holder.itemView;
 				ViewCompat.postOnAnimationDelayed(view, mover, getRemoveDuration());
 			} else {
-				mover.run();
+				new Thread(mover).start();
 			}
 		}
 	}
@@ -144,7 +144,7 @@ public abstract class PendingItemAnimator<H extends ViewHolder> extends SimpleIt
 						, (removalsPending ? getRemoveDuration() : 0)
 						+ (movesPending ? getMoveDuration() : 0));
 			} else {
-				adder.run();
+				new Thread(adder).start();
 			}
 		}
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1217 - Thread.run() and Runnable.run() should not be called directly.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1217
Please let me know if you have any questions.
George Kankava