### PR TITLE
getItemViewType now returns zero when item not found

### DIFF
--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -1783,6 +1783,9 @@ public class FlexibleAdapter<T extends IFlexible>
 	@Override
 	public int getItemViewType(int position) {
 		T item = getItem(position);
+		if (item == null) {
+			return 0;
+		}
 		// Map the view type if not done yet
 		mapViewTypeFrom(item);
 		autoMap = true;


### PR DESCRIPTION
I added a custom 'ItemDecoration' to the recycler view meant for adding dividers to only specific item types and used "getItemViewType" to resolve type for a given position.
When using scrollable expandable header, I ran into NPE since my custom ItemDecoration
tried to resolve type for a position for which 'getItem' returned null.

Maybe for these cases, 'getItemViewType' can instead return '0' which is the default base adapter's implementation and also does not represent any valid layout res id.

