### PR TITLE
BUG FIX: Allow usage of Parcelable for IHeaders and IFlexible.

### DIFF
--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -1628,7 +1628,7 @@ public class FlexibleAdapter<T extends IFlexible>
 			T item = getItem(position);
 			// Reset hidden status! Necessary after the filter and the update
 			IHeader header = getHeaderOf(item);
-			if (header != sameHeader && header != null && !isExpandable((T) header)) {
+			if (!header.equals(sameHeader) && header != null && !isExpandable((T) header)) {
 				sameHeader = header;
 				header.setHidden(true);
 			}
@@ -4220,7 +4220,7 @@ public class FlexibleAdapter<T extends IFlexible>
 			// Restore headers visibility
 			if (headersShown) {
 				IHeader header = getHeaderOf(item);
-				if (header != sameHeader && header != null && !isExpandable((T) header)) {
+				if (!header.equals(sameHeader) && header != null && !isExpandable((T) header)) {
 					header.setHidden(false);
 					sameHeader = header;
 					items.add(i, (T) header);
@@ -5503,7 +5503,7 @@ public class FlexibleAdapter<T extends IFlexible>
 				headersShown = true;
 			}
 			IHeader header = getHeaderOf(item);
-			if (header != sameHeader && header != null && !isExpandable((T) header)) {
+			if (header.equals(sameHeader) && header != null && !isExpandable((T) header)) {
 				header.setHidden(false);
 				sameHeader = header;
 				newItems.add(position, (T) header);


### PR DESCRIPTION
If you pass the Items or Headers to an Intent as a Parcelable the headers
are recreated as different instances and are shown above each item and not
the whole section. The reason for this of the usage of reference equality
check. We need to use the equal() to fix this issue.