### PR TITLE
Fixing expansion of subitems during update (now works like expand all at startup)

### DIFF
--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -5552,10 +5552,8 @@ public class FlexibleAdapter<T extends IFlexible>
 				int itemCount = newItems.size();
 				if (position < itemCount) {
 					newItems.addAll(position + 1, subItems);
-					position += subItems.size();
 				} else {
 					newItems.addAll(subItems);
-					position = itemCount;
 				}
 			}
 			// Display headers too


### PR DESCRIPTION
Removed advancement of position beyond subitems such that now all subitem positions will be checked for nested expansion during update. Previously only top level items were checked for their expansion status during update and subitems, regardless of expansion status, were ignored.