### PR TITLE
Fix invalid first page number when initializing with empty list/null

### DIFF
--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -1843,7 +1843,10 @@ public class FlexibleAdapter<T extends IFlexible>
      * @since 5.0.0-rc1
      */
     public int getEndlessCurrentPage() {
-        return mEndlessPageSize > 0 ? getMainItemCount() / mEndlessPageSize : 0;
+        if (mEndlessPageSize > 0) {
+            return (int) Math.ceil((double) getMainItemCount() / mEndlessPageSize);
+        }
+        return 0;
     }
 
     /**

--- a/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
+++ b/flexible-adapter/src/main/java/eu/davidea/flexibleadapter/FlexibleAdapter.java
@@ -1835,7 +1835,7 @@ public class FlexibleAdapter<T extends IFlexible>
 
     /**
      * Provides the current endless page if the page size limit is set, if not set the returned
-     * value is always 1.
+     * value is always 0.
      *
      * @return the current endless page
      * @see #getEndlessPageSize()
@@ -1843,7 +1843,7 @@ public class FlexibleAdapter<T extends IFlexible>
      * @since 5.0.0-rc1
      */
     public int getEndlessCurrentPage() {
-        return Math.max(1, mEndlessPageSize > 0 ? getMainItemCount() / mEndlessPageSize : 0);
+        return mEndlessPageSize > 0 ? getMainItemCount() / mEndlessPageSize : 0;
     }
 
     /**


### PR DESCRIPTION
When using endless scrolling and initializing the adapter with empty list or null, first two onLoadMore() calls have a page number 1. A simple fix would be to start counting from 0 instead.