### PR TITLE
Fix missing Lifecycle dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ allprojects {
         targetSdk = 30 // Android 11
 
         // AndroidX
-        androidxVer = '1.3.0'
+        browserVer = '1.3.0'
         appCompatVer = '1.2.0'
         cardviewVer = '1.0.0'
         annotationVer = '1.1.0'
@@ -36,9 +36,10 @@ allprojects {
                 appCompat          : "androidx.appcompat:appcompat:${appCompatVer}",
                 cardView           : "androidx.cardview:cardview:${cardviewVer}",
                 annotation         : "androidx.annotation:annotation:${annotationVer}",
-                browser            : "androidx.browser:browser:${androidxVer}",
+                browser            : "androidx.browser:browser:${browserVer}",
                 vectorDrawable     : "androidx.vectordrawable:vectordrawable:${vectorDrawableVer}",
                 transition         : "androidx.transition:transition:${transitionVer}",
+                lifecycleLiveData  : "androidx.lifecycle:lifecycle-livedata-ktx:${lifecycleVer}",
                 lifecycleExtensions: "androidx.lifecycle:lifecycle-viewmodel-ktx:${lifecycleVer}",
                 constraintLayout   : "androidx.constraintlayout:constraintlayout:${constraintVer}",
                 core               : "androidx.core:core:${coreVer}",

--- a/flexible-adapter-livedata/build.gradle
+++ b/flexible-adapter-livedata/build.gradle
@@ -50,6 +50,7 @@ android {
 
 dependencies {
     // Lifecycle
+    implementation androidx.lifecycleLiveData
     implementation androidx.lifecycleExtensions
 
     // Test libraries


### PR DESCRIPTION
This fixes the ability to consume the libraries via JitPack and somewhat addresses #768. I didn't test if it allows for publishing to Maven Central or not.

For example:

Root `build.gradle`:

```groovy
allprojects {
	repositories {
		...
		maven { url 'https://jitpack.io' }
	}
}
```

In your module's `build.gradle`:

```groovy
dependencies {
        final flexible_adapter_version = 'c8013533';
        implementation 'com.github.arkon.FlexibleAdapter:flexible-adapter:$flexible_adapter_version'
        implementation 'com.github.arkon.FlexibleAdapter:flexible-adapter-databinding:$flexible_adapter_version'
        implementation 'com.github.arkon.FlexibleAdapter:flexible-adapter-livedata:$flexible_adapter_version'
        implementation 'com.github.arkon.FlexibleAdapter:flexible-adapter-ui:$flexible_adapter_version'
}
```